### PR TITLE
Fix Android TV D-pad accessibility

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
         compileSdk { version = release(providers.gradleProperty("android.compileSdk").get().toInt()) }
         minSdk = providers.gradleProperty("android.minSdk").get().toInt()
         androidResources { enable = true }
+        withHostTest {}
     }
 
     // Activating iOS targets (iosMain)

--- a/shared/src/androidMain/kotlin/app/uicomponents/TvFocus.android.kt
+++ b/shared/src/androidMain/kotlin/app/uicomponents/TvFocus.android.kt
@@ -1,0 +1,64 @@
+package app.uicomponents
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.os.SystemClock
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreInterceptKeyBeforeSoftKeyboard
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+@Composable
+internal actual fun Modifier.onTvTextFieldNavigationKeyEvent(
+    onKeyEvent: (KeyEvent) -> Boolean,
+): Modifier {
+    val localView = LocalView.current
+    val insetView = localView.context.findActivity()?.window?.decorView ?: localView
+    val imeDismissalRequestedAt = remember { longArrayOf(0L) }
+
+    return onPreInterceptKeyBeforeSoftKeyboard { event ->
+        val imeVisible = ViewCompat.getRootWindowInsets(insetView)
+            ?.isVisible(WindowInsetsCompat.Type.ime()) == true
+        val now = SystemClock.uptimeMillis()
+
+        if (imeVisible &&
+            event.type == KeyEventType.KeyDown &&
+            event.key == Key.Back
+        ) {
+            imeDismissalRequestedAt[0] = now
+            return@onPreInterceptKeyBeforeSoftKeyboard false
+        }
+
+        val imeDismissalPending = imeVisible &&
+            now - imeDismissalRequestedAt[0] in 0..IME_DISMISSAL_GRACE_PERIOD_MS
+        if (!imeVisible || !imeDismissalPending) {
+            imeDismissalRequestedAt[0] = 0L
+        }
+
+        val shouldRoute = shouldRouteTvTextFieldNavigation(imeVisible, imeDismissalPending) &&
+            event.type == KeyEventType.KeyDown &&
+            tvFocusDirection(event.key) != null
+        if (shouldRoute) {
+            imeDismissalRequestedAt[0] = 0L
+            localView.post { onKeyEvent(event) }
+        }
+        shouldRoute
+    }
+}
+
+private const val IME_DISMISSAL_GRACE_PERIOD_MS = 2_000L
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/shared/src/androidMain/kotlin/app/utils/PlatformUtils.android.kt
+++ b/shared/src/androidMain/kotlin/app/utils/PlatformUtils.android.kt
@@ -3,6 +3,8 @@ package app.utils
 import android.content.ContentResolver
 import android.content.Context
 import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.provider.DocumentsContract
@@ -42,6 +44,14 @@ import SyncplayMobile.shared.BuildConfig
 
 
 actual val platform: Platform = Platform.Android
+
+actual val isTelevision: Boolean
+    get() {
+        val context = contextObtainer()
+        val uiModeIsTelevision = context.resources.configuration.uiMode and
+            Configuration.UI_MODE_TYPE_MASK == Configuration.UI_MODE_TYPE_TELEVISION
+        return uiModeIsTelevision || context.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
+    }
 
 /* Lazily cached singleton so one OkHttp engine is shared and connection pooling works.
  * HttpTimeout fails fast on flaky CDNs; User-Agent is set for CDNs that filter on it. */

--- a/shared/src/commonMain/kotlin/app/home/components/HomeTextField.kt
+++ b/shared/src/commonMain/kotlin/app/home/components/HomeTextField.kt
@@ -45,6 +45,7 @@ import app.theme.Theming.flexibleGradient
 import app.uicomponents.FlexibleIcon
 import app.uicomponents.gradientOverlay
 import app.uicomponents.tvFocusable
+import app.uicomponents.tvTextFieldNavigation
 import com.composeunstyled.UnstyledIcon
 
 // Uses BasicTextField directly rather than compose-unstyled's UnstyledTextField + TextInput:
@@ -93,12 +94,14 @@ fun HomeTextField(
     val textColor = MaterialTheme.colorScheme.onTertiaryContainer
 
     BasicTextField(
-        state = state,
-        modifier = modifier.tvFocusable(
-            focusRequester = focusRequester,
-            shape = shape,
-            addFocusable = false,
-        ),
+            state = state,
+            modifier = modifier
+                .tvFocusable(
+                    focusRequester = focusRequester,
+                    shape = shape,
+                    addFocusable = false,
+                )
+                .tvTextFieldNavigation(enabled = enabled && dropdownState == null),
         textStyle = TextStyle(color = textColor, textAlign = TextAlign.Center),
         lineLimits = TextFieldLineLimits.SingleLine,
         enabled = enabled,
@@ -152,6 +155,6 @@ fun HomeTextField(
                     )
                 }
             }
-        },
-    )
+            },
+        )
 }

--- a/shared/src/commonMain/kotlin/app/preferences/settings/PopupTrustedDomains.kt
+++ b/shared/src/commonMain/kotlin/app/preferences/settings/PopupTrustedDomains.kt
@@ -29,6 +29,7 @@ import app.preferences.Preferences
 import app.preferences.set
 import app.preferences.value
 import app.uicomponents.SyncplayPopup
+import app.uicomponents.tvTextFieldNavigation
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
@@ -78,7 +79,7 @@ fun TrustedDomainsPopup(visibilityState: MutableState<Boolean>) {
             BasicTextField(
                 value = text,
                 onValueChange = { text = it },
-                modifier = Modifier.fillMaxWidth().weight(1f),
+                modifier = Modifier.fillMaxWidth().weight(1f).tvTextFieldNavigation(),
                 textStyle = TextStyle(
                     color = MaterialTheme.colorScheme.onSurface,
                     fontSize = 14.sp,

--- a/shared/src/commonMain/kotlin/app/room/ui/bottombar/PopupSeekToPosition.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/bottombar/PopupSeekToPosition.kt
@@ -50,6 +50,7 @@ import app.theme.Theming
 import app.uicomponents.FlexibleText
 import app.uicomponents.SyncplayPopup
 import app.uicomponents.syncplayFont
+import app.uicomponents.tvTextFieldNavigation
 import app.utils.timestampFromMillis
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.getString
@@ -116,7 +117,9 @@ object PopupSeekToPosition {
                     horizontalArrangement = Arrangement.Center
                 ) {
                     TextField(
-                        modifier = Modifier.width(64.dp).focusRequester(hhRequester),
+                        modifier = Modifier.width(64.dp)
+                            .focusRequester(hhRequester)
+                            .tvTextFieldNavigation(right = mmRequester),
                         shape = RoundedCornerShape(12.dp),
                         singleLine = true,
                         value = hours.value,
@@ -145,7 +148,9 @@ object PopupSeekToPosition {
 
 
                     TextField(
-                        modifier = Modifier.width(64.dp).focusRequester(mmRequester),
+                        modifier = Modifier.width(64.dp)
+                            .focusRequester(mmRequester)
+                            .tvTextFieldNavigation(left = hhRequester, right = ssRequester),
                         shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
                         singleLine = true,
                         value = minutes.value,
@@ -173,7 +178,9 @@ object PopupSeekToPosition {
                     Spacer(Modifier.width(12.dp))
 
                     TextField(
-                        modifier = Modifier.width(64.dp).focusRequester(ssRequester),
+                        modifier = Modifier.width(64.dp)
+                            .focusRequester(ssRequester)
+                            .tvTextFieldNavigation(left = mmRequester),
                         shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
                         singleLine = true,
                         value = seconds.value,

--- a/shared/src/commonMain/kotlin/app/room/ui/bottombar/RoomControlPanel.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/bottombar/RoomControlPanel.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -61,6 +62,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
@@ -96,6 +99,8 @@ import app.theme.Theming.flexibleGradient
 import app.uicomponents.FlexibleIcon
 import app.uicomponents.FlexibleText
 import app.uicomponents.jostFont
+import app.uicomponents.tvTextFieldNavigation
+import app.uicomponents.tvFocusProperties
 import app.utils.ccExs
 import app.utils.timestampFromMillis
 import com.composeunstyled.Thumb
@@ -566,6 +571,7 @@ fun RoomControlPanelCard(modifier: Modifier) {
         var isSearching by remember { mutableStateOf(false) }
         var isDownloading by remember { mutableStateOf<Int?>(null) }
         val searchListState = rememberLazyListState()
+        val searchButtonFocusRequester = remember { FocusRequester() }
 
         fun doSearch() {
             if (searchQuery.isBlank()) return
@@ -602,24 +608,32 @@ fun RoomControlPanelCard(modifier: Modifier) {
                     modifier = Modifier.align(Alignment.CenterHorizontally).padding(bottom = 8.dp)
                 )
 
-                OutlinedTextField(
-                    value = searchQuery,
-                    onValueChange = { searchQuery = it },
-                    singleLine = true,
-                    label = { Text(stringResource(Res.string.room_sub_search_hint), fontSize = 12.sp) },
-                    trailingIcon = {
-                        Icon(
-                            Icons.Filled.Search, null,
-                            modifier = Modifier.clickable { doSearch() }
-                        )
-                    },
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                    keyboardActions = KeyboardActions(
-                        onSearch = { doSearch() },
-                        onDone = { doSearch() }
-                    ),
+                Box(
                     modifier = Modifier.fillMaxWidth()
-                )
+                        .tvTextFieldNavigation(right = searchButtonFocusRequester),
+                ) {
+                    OutlinedTextField(
+                        value = searchQuery,
+                        onValueChange = { searchQuery = it },
+                        singleLine = true,
+                        label = { Text(stringResource(Res.string.room_sub_search_hint), fontSize = 12.sp) },
+                        trailingIcon = {
+                            IconButton(
+                                modifier = Modifier.focusRequester(searchButtonFocusRequester),
+                                onClick = { doSearch() },
+                            ) {
+                                Icon(Icons.Filled.Search, null)
+                            }
+                        },
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                        keyboardActions = KeyboardActions(
+                            onSearch = { doSearch() },
+                            onDone = { doSearch() }
+                        ),
+                        modifier = Modifier.fillMaxWidth()
+                            .tvFocusProperties { right = searchButtonFocusRequester },
+                    )
+                }
 
                 Spacer(Modifier.height(8.dp))
 

--- a/shared/src/commonMain/kotlin/app/room/ui/bottombar/RoomMediaAddButton.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/bottombar/RoomMediaAddButton.kt
@@ -43,6 +43,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboard
@@ -67,9 +69,11 @@ import app.uicomponents.jostFont
 import app.uicomponents.sairaFont
 import app.uicomponents.syncplayFont
 import app.uicomponents.tvFocusable
-import androidx.compose.ui.focus.focusRequester
+import app.uicomponents.tvFocusProperties
+import app.uicomponents.tvTextFieldNavigation
 import app.utils.Platform
 import app.utils.getText
+import app.utils.isTelevision
 import app.utils.loggy
 import app.utils.platform
 import app.utils.platformCallback
@@ -289,6 +293,32 @@ fun AddUrlPopup(visibilityState: MutableState<Boolean>) {
         val scope = rememberCoroutineScope()
         val viewmodel = LocalRoomViewmodel.current
         val clipboard = LocalClipboard.current
+        val urlFocusRequester = remember { FocusRequester() }
+        val pasteFocusRequester = remember { FocusRequester() }
+        val doneFocusRequester = remember { FocusRequester() }
+        val url = remember { mutableStateOf("") }
+        val pasteUrl: () -> Unit = {
+            scope.launch {
+                clipboard.getClipEntry()?.getText()?.let { clipboardData ->
+                    url.value = clipboardData
+                }
+            }
+        }
+        val submitUrl: () -> Unit = {
+            visibilityState.value = false
+            if (url.value.trim().isNotBlank()) {
+                viewmodel.viewModelScope.launch {
+                    viewmodel.player.injectVideoURL(url.value.trim())
+                }
+            }
+        }
+
+        LaunchedEffect(Unit) {
+            if (isTelevision) {
+                delay(100)
+                runCatching { urlFocusRequester.requestFocus() }
+            }
+        }
 
         Column(
             modifier = Modifier.fillMaxSize().padding(6.dp),
@@ -318,61 +348,85 @@ fun AddUrlPopup(visibilityState: MutableState<Boolean>) {
             Spacer(Modifier.height(2.dp))
 
             /* The URL input box */
-            val url = remember { mutableStateOf("") }
-            TextField(
-                modifier = Modifier.fillMaxWidth(0.9f),
-                shape = RoundedCornerShape(16.dp),
-                singleLine = true,
-                value = url.value,
-                colors = TextFieldDefaults.colors(
-                    focusedContainerColor = Color.DarkGray,
-                    unfocusedContainerColor = Color.DarkGray,
-                    disabledContainerColor = Color.DarkGray,
-                    focusedIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent,
-                    disabledIndicatorColor = Color.Transparent,
-                ),
-                trailingIcon = {
-                    IconButton(onClick = {
-                        scope.launch {
-                            clipboard.getClipEntry()?.getText()?.let { clipboardData ->
-                                url.value = clipboardData
-                            }
-                        }
-                    }) {
-                        Icon(imageVector = Icons.Filled.ContentPaste, "", tint = MaterialTheme.colorScheme.primary)
-                    }
-                },
-                leadingIcon = {
-                    Icon(imageVector = Icons.Filled.Link, "", tint = MaterialTheme.colorScheme.primary)
-                },
-                onValueChange = { url.value = it },
-                textStyle = TextStyle(
-                    brush = Brush.linearGradient(
-                        colors = Theming.SP_GRADIENT
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center,
+            ) {
+                TextField(
+                    modifier = Modifier
+                        .fillMaxWidth(0.9f)
+                        .focusRequester(urlFocusRequester)
+                        .tvTextFieldNavigation(
+                            right = pasteFocusRequester,
+                            down = doneFocusRequester,
+                        )
+                        .tvFocusProperties {
+                            right = pasteFocusRequester
+                            down = doneFocusRequester
+                        },
+                    shape = RoundedCornerShape(16.dp),
+                    singleLine = true,
+                    value = url.value,
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.DarkGray,
+                        unfocusedContainerColor = Color.DarkGray,
+                        disabledContainerColor = Color.DarkGray,
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                        disabledIndicatorColor = Color.Transparent,
                     ),
-                    fontFamily = FontFamily(syncplayFont),
-                    fontSize = 16.sp,
-                ),
-                label = {
-                    Text(stringResource(Res.string.room_addmedia_online_url), color = Color.Gray)
-                }
-            )
+                    trailingIcon = {
+                        IconButton(
+                            modifier = Modifier
+                                .tvFocusProperties {
+                                    left = urlFocusRequester
+                                    down = doneFocusRequester
+                                }
+                                .tvFocusable(
+                                    focusRequester = pasteFocusRequester,
+                                    enabled = isTelevision,
+                                    scaleWhenFocused = 1f,
+                                    onActivate = pasteUrl,
+                                ),
+                            onClick = pasteUrl,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.ContentPaste,
+                                contentDescription = "",
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    },
+                    leadingIcon = {
+                        Icon(imageVector = Icons.Filled.Link, "", tint = MaterialTheme.colorScheme.primary)
+                    },
+                    onValueChange = { url.value = it },
+                    textStyle = TextStyle(
+                        brush = Brush.linearGradient(
+                            colors = Theming.SP_GRADIENT
+                        ),
+                        fontFamily = FontFamily(syncplayFont),
+                        fontSize = 16.sp,
+                    ),
+                    label = {
+                        Text(stringResource(Res.string.room_addmedia_online_url), color = Color.Gray)
+                    }
+                )
+            }
 
             /* Ok button */
             Button(
+                modifier = Modifier
+                    .tvFocusProperties { up = urlFocusRequester }
+                    .tvFocusable(
+                        focusRequester = doneFocusRequester,
+                        enabled = isTelevision,
+                        scaleWhenFocused = 1f,
+                        onActivate = submitUrl,
+                    ),
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
                 border = BorderStroke(width = 1.dp, color = Color.Black),
-                onClick = {
-                    visibilityState.value = false
-
-                    if (url.value.trim().isNotBlank()) {
-                        viewmodel.viewModelScope.launch {
-                            viewmodel.player.injectVideoURL(url.value.trim())
-                        }
-                    }
-
-                },
+                onClick = submitUrl,
             ) {
                 Icon(imageVector = Icons.Filled.Done, "")
                 Spacer(modifier = Modifier.width(8.dp))

--- a/shared/src/commonMain/kotlin/app/room/ui/rightcards/CardSharedPlaylist.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/rightcards/CardSharedPlaylist.kt
@@ -60,6 +60,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -82,7 +84,10 @@ import app.uicomponents.gradientOverlay
 import app.uicomponents.helveticaFont
 import app.uicomponents.jostFont
 import app.uicomponents.tvFocusable
+import app.uicomponents.tvFocusProperties
+import app.uicomponents.tvTextFieldNavigation
 import app.utils.appName
+import app.utils.isTelevision
 import app.utils.playlistExs
 import app.utils.videoFileKitType
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
@@ -93,6 +98,7 @@ import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
 import io.github.vinceglb.filekit.dialogs.compose.rememberFileSaverLauncher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.Font
 import org.jetbrains.compose.resources.getString
@@ -478,6 +484,15 @@ object CardSharedPlaylist {
         ) {
             val playlist = LocalRoomViewmodel.current.playlistManager
             val clipboardManager = LocalClipboardManager.current
+            val urlsFocusRequester = remember { FocusRequester() }
+            val doneFocusRequester = remember { FocusRequester() }
+
+            LaunchedEffect(Unit) {
+                if (isTelevision) {
+                    delay(100)
+                    runCatching { urlsFocusRequester.requestFocus() }
+                }
+            }
 
             Column(
                 modifier = Modifier.fillMaxSize().padding(6.dp),
@@ -500,39 +515,48 @@ object CardSharedPlaylist {
                 )
 
                 val urls = remember { mutableStateOf("") }
-                TextField(
-                    modifier = Modifier.fillMaxWidth(0.9f),
-                    shape = RoundedCornerShape(16.dp),
-                    value = urls.value,
-                    colors = TextFieldDefaults.colors(
-                        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent,
-                    ),
-                    trailingIcon = {
-                        IconButton(onClick = {
-                            urls.value = clipboardManager.getText().toString()
-                        }) {
-                            Icon(imageVector = Icons.Filled.ContentPaste, "", tint = MaterialTheme.colorScheme.primary)
+                Box(
+                    modifier = Modifier.fillMaxWidth()
+                        .tvTextFieldNavigation(down = doneFocusRequester),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    TextField(
+                        modifier = Modifier.fillMaxWidth(0.9f)
+                            .focusRequester(urlsFocusRequester)
+                            .tvFocusProperties { down = doneFocusRequester },
+                        shape = RoundedCornerShape(16.dp),
+                        value = urls.value,
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                        ),
+                        trailingIcon = {
+                            IconButton(onClick = {
+                                urls.value = clipboardManager.getText().toString()
+                            }) {
+                                Icon(imageVector = Icons.Filled.ContentPaste, "", tint = MaterialTheme.colorScheme.primary)
+                            }
+                        },
+                        leadingIcon = {
+                            Icon(imageVector = Icons.Filled.Link, "", tint = MaterialTheme.colorScheme.primary)
+                        },
+                        onValueChange = { urls.value = it },
+                        textStyle = TextStyle(
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontFamily = FontFamily(helveticaFont),
+                            fontSize = 16.sp,
+                        ),
+                        singleLine = true,
+                        label = {
+                            Text("URLs", color = Color.Gray)
                         }
-                    },
-                    leadingIcon = {
-                        Icon(imageVector = Icons.Filled.Link, "", tint = MaterialTheme.colorScheme.primary)
-                    },
-                    onValueChange = { urls.value = it },
-                    textStyle = TextStyle(
-                        color = MaterialTheme.colorScheme.onSurface,
-                        fontFamily = FontFamily(helveticaFont),
-                        fontSize = 16.sp,
-                    ),
-                    singleLine = true,
-                    label = {
-                        Text("URLs", color = Color.Gray)
-                    }
-                )
+                    )
+                }
 
                 Button(
+                    modifier = Modifier.focusRequester(doneFocusRequester),
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
                     onClick = {
                         visibilityState.value = false

--- a/shared/src/commonMain/kotlin/app/room/ui/tabs/PopupManagedRoom.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/tabs/PopupManagedRoom.kt
@@ -37,6 +37,7 @@ import app.theme.Theming.flexibleGradient
 import app.uicomponents.FlexibleText
 import app.uicomponents.SyncplayPopup
 import app.uicomponents.jostFont
+import app.uicomponents.tvTextFieldNavigation
 import app.utils.generateRoomPassword
 import org.jetbrains.compose.resources.stringResource
 import syncplaymobile.shared.generated.resources.Res
@@ -105,7 +106,7 @@ fun ManagedRoomPopup(purpose: ManagedRoomPopupPurpose) {
             )
 
             TextField(
-                modifier = Modifier.fillMaxWidth().padding(6.dp), singleLine = true, value = inputValue, keyboardActions = KeyboardActions(onDone = {
+                modifier = Modifier.fillMaxWidth().padding(6.dp).tvTextFieldNavigation(), singleLine = true, value = inputValue, keyboardActions = KeyboardActions(onDone = {
                     focusManager.clearFocus(true)
                 }), colors = TextFieldDefaults.colors(
                     focusedContainerColor = Color.DarkGray,

--- a/shared/src/commonMain/kotlin/app/room/ui/tabs/RoomSectionTabs.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/tabs/RoomSectionTabs.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,6 +35,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
@@ -43,6 +45,9 @@ import app.LocalRoomUiState
 import app.LocalRoomViewmodel
 import app.room.RoomUiStateManager.Companion.RoomOrientation
 import app.uicomponents.FlexibleIcon
+import app.uicomponents.tvFocusable
+import app.uicomponents.tvFocusProperties
+import app.utils.isTelevision
 import app.utils.platformCallback
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -128,6 +133,13 @@ fun RoomTabSection(modifier: Modifier) {
 
         Box {
             val overflowMenuState = remember { mutableStateOf(false) }
+            val pipFocusRequester = remember { FocusRequester() }
+            val createRoomFocusRequester = remember { FocusRequester() }
+            val identifyFocusRequester = remember { FocusRequester() }
+            val leaveRoomFocusRequester = remember { FocusRequester() }
+            val managedRoomsAreSupported by viewmodel.protocol.supportsManagedRooms.collectAsState()
+            val showsPip = viewmodel.player.supportsPictureInPicture
+            val showsManagedRoomActions = !viewmodel.isSoloMode && managedRoomsAreSupported
             FlexibleIcon(
                 icon = Icons.Filled.MoreVert,
                 size = 48,
@@ -136,11 +148,25 @@ fun RoomTabSection(modifier: Modifier) {
                 overflowMenuState.value = !overflowMenuState.value
             }
 
+            LaunchedEffect(overflowMenuState.value) {
+                if (isTelevision && overflowMenuState.value) {
+                    when {
+                        showsPip -> pipFocusRequester
+                        showsManagedRoomActions -> createRoomFocusRequester
+                        else -> leaveRoomFocusRequester
+                    }.requestFocus()
+                }
+            }
+
             DropdownMenu(
                 containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                 shape = RoundedCornerShape(12.dp),
                 expanded = overflowMenuState.value,
-                properties = PopupProperties(dismissOnBackPress = true, dismissOnClickOutside = true),
+                properties = PopupProperties(
+                    focusable = isTelevision,
+                    dismissOnBackPress = true,
+                    dismissOnClickOutside = true,
+                ),
                 onDismissRequest = {
                     scope.launch {
                         delay(50)
@@ -155,9 +181,15 @@ fun RoomTabSection(modifier: Modifier) {
                     color = MaterialTheme.colorScheme.primary,
                 )
 
-                if (viewmodel.player.supportsPictureInPicture) {
+                if (showsPip) {
                     /* Picture-in-Picture mode */
                     RoomOverflowItem(
+                        focusRequester = pipFocusRequester,
+                        down = if (showsManagedRoomActions) {
+                            createRoomFocusRequester
+                        } else {
+                            leaveRoomFocusRequester
+                        },
                         text = stringResource(Res.string.room_overflow_pip),
                         icon = Icons.Filled.PictureInPicture,
                         onClick = {
@@ -167,32 +199,34 @@ fun RoomTabSection(modifier: Modifier) {
                     )
                 }
 
-                val managedRoomAreSupported by viewmodel.protocol.supportsManagedRooms.collectAsState()
-                if (!viewmodel.isSoloMode) {
-                    if (managedRoomAreSupported) {
-                        /* Create managed room */
-                        RoomOverflowItem(
-                            text = stringResource(Res.string.room_overflow_create_managed_room),
-                            icon = Icons.Filled.SupervisedUserCircle,
-                            onClick = {
-                                overflowMenuState.value = false
-                                viewmodel.uiState.popupCreateManagedRoom.value = true
-                            }
-                        )
+                if (showsManagedRoomActions) {
+                    /* Create managed room */
+                    RoomOverflowItem(
+                        focusRequester = createRoomFocusRequester,
+                        up = if (showsPip) pipFocusRequester else null,
+                        down = identifyFocusRequester,
+                        text = stringResource(Res.string.room_overflow_create_managed_room),
+                        icon = Icons.Filled.SupervisedUserCircle,
+                        onClick = {
+                            overflowMenuState.value = false
+                            viewmodel.uiState.popupCreateManagedRoom.value = true
+                        }
+                    )
 
-                        /* Identify as room operator */
-                        RoomOverflowItem(
-                            text = stringResource(Res.string.room_overflow_identify_as_operator),
-                            icon = Icons.Filled.SupervisorAccount,
-                            onClick = {
-                                overflowMenuState.value = false
+                    /* Identify as room operator */
+                    RoomOverflowItem(
+                        focusRequester = identifyFocusRequester,
+                        up = createRoomFocusRequester,
+                        down = leaveRoomFocusRequester,
+                        text = stringResource(Res.string.room_overflow_identify_as_operator),
+                        icon = Icons.Filled.SupervisorAccount,
+                        onClick = {
+                            overflowMenuState.value = false
 
-                                //TODO: Check if user is already operator
-                                viewmodel.uiState.popupIdentifyAsRoomOperator.value = true
-                            }
-                        )
-                    }
-
+                            //TODO: Check if user is already operator
+                            viewmodel.uiState.popupIdentifyAsRoomOperator.value = true
+                        }
+                    )
                 }
 
                 /* Toggle portrait/landscape mode */
@@ -200,6 +234,7 @@ fun RoomTabSection(modifier: Modifier) {
                     val currentOrientation by cardController.roomOrientation.collectAsState()
                     val isCurrentlyPortrait = currentOrientation == RoomOrientation.PORTRAIT
                     RoomOverflowItem(
+                        focusRequester = leaveRoomFocusRequester,
                         text = stringResource(
                             if (isCurrentlyPortrait) Res.string.room_overflow_landscape_mode
                             else Res.string.room_overflow_portrait_mode
@@ -215,6 +250,12 @@ fun RoomTabSection(modifier: Modifier) {
 
                 /* Leave room item */
                 RoomOverflowItem(
+                    focusRequester = leaveRoomFocusRequester,
+                    up = when {
+                        showsManagedRoomActions -> identifyFocusRequester
+                        showsPip -> pipFocusRequester
+                        else -> null
+                    },
                     text = stringResource(Res.string.room_overflow_leave_room),
                     icon = Icons.AutoMirrored.Filled.Logout,
                     onClick = {
@@ -233,9 +274,23 @@ fun RoomTabSection(modifier: Modifier) {
 fun RoomOverflowItem(
     text: String,
     icon: ImageVector,
+    focusRequester: FocusRequester,
+    up: FocusRequester? = null,
+    down: FocusRequester? = null,
     onClick: () -> Unit
 ) {
     DropdownMenuItem(
+        modifier = Modifier
+            .tvFocusProperties {
+                up?.let { this.up = it }
+                down?.let { this.down = it }
+            }
+            .tvFocusable(
+                focusRequester = focusRequester,
+                enabled = isTelevision,
+                scaleWhenFocused = 1f,
+                onActivate = onClick,
+            ),
         leadingIcon = { Icon(imageVector = icon, contentDescription = null) },
         text = { Text(text = text) },
         onClick = onClick

--- a/shared/src/commonMain/kotlin/app/uicomponents/SyncplayPopup.kt
+++ b/shared/src/commonMain/kotlin/app/uicomponents/SyncplayPopup.kt
@@ -3,6 +3,7 @@ package app.uicomponents
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -24,6 +25,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import app.theme.Theming.backgroundGradient
 import app.theme.Theming.flexibleGradient
+import app.utils.isTelevision
 
 /** Shows a popup with the given content.
  * @param dialogOpen Controls whether the popup dialog is shown or not.
@@ -65,6 +67,7 @@ fun SyncplayPopup(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(Color.Black.copy(alpha = 0.5f))
+                    .tvFocusProperties { canFocus = false }
                     .then(
                         if (dismissable) Modifier.clickable(
                             interactionSource = null,
@@ -79,6 +82,8 @@ fun SyncplayPopup(
                         .run { if (widthPercent == 0f) this else fillMaxWidth(widthPercent) }
                         .run { if (heightPercent == 0f) this else fillMaxHeight(heightPercent) }
                         .padding(24.dp)
+                        .then(if (isTelevision) Modifier.focusGroup() else Modifier)
+                        .tvFocusProperties { canFocus = false }
                         .clickable(
                             interactionSource = null,
                             indication = null

--- a/shared/src/commonMain/kotlin/app/uicomponents/TvFocus.kt
+++ b/shared/src/commonMain/kotlin/app/uicomponents/TvFocus.kt
@@ -6,20 +6,32 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusProperties
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.theme.Theming.flexibleGradient
+import app.utils.isTelevision
 
 /**
  * Marks a composable as D-pad-navigable with an animated focus indicator.
@@ -40,6 +52,7 @@ fun Modifier.tvFocusable(
     borderWidth: Dp = 2.dp,
     scaleWhenFocused: Float = 1.04f,
     addFocusable: Boolean = true,
+    onActivate: (() -> Unit)? = null,
 ): Modifier {
     if (!enabled) return this
     var focused by remember { mutableStateOf(false) }
@@ -63,5 +76,100 @@ fun Modifier.tvFocusable(
                 focused = newFocused
             }
         }
+        .then(
+            if (isTelevision && onActivate != null) {
+                Modifier.onKeyEvent { event ->
+                    if (event.type == KeyEventType.KeyDown && isTvActivationKey(event.key)) {
+                        onActivate()
+                        true
+                    } else {
+                        false
+                    }
+                }
+            } else {
+                Modifier
+            }
+        )
         .then(if (addFocusable) Modifier.focusable() else Modifier)
+}
+
+/**
+ * On TV, directional keys must leave a text editor and continue through the focus graph. Without
+ * this, BasicTextField/TextField consume D-pad events as caret movement and trap remote users.
+ */
+@Composable
+fun Modifier.tvTextFieldNavigation(
+    enabled: Boolean = true,
+    up: FocusRequester? = null,
+    down: FocusRequester? = null,
+    left: FocusRequester? = null,
+    right: FocusRequester? = null,
+): Modifier {
+    if (!shouldInterceptTvTextFieldNavigation(enabled, isTelevision)) return this
+
+    val focusManager = LocalFocusManager.current
+    var pendingDirection by remember { mutableStateOf<FocusDirection?>(null) }
+
+    LaunchedEffect(pendingDirection) {
+        val direction = pendingDirection ?: return@LaunchedEffect
+        val target = when (direction) {
+            FocusDirection.Up -> up
+            FocusDirection.Down -> down
+            FocusDirection.Left -> left
+            FocusDirection.Right -> right
+            else -> null
+        }
+
+        target?.requestFocus()?.takeIf { it } ?: focusManager.moveFocus(direction)
+        pendingDirection = null
+    }
+
+    return this
+        .onTvTextFieldNavigationKeyEvent { event ->
+            if (event.type != KeyEventType.KeyDown) {
+                return@onTvTextFieldNavigationKeyEvent false
+            }
+
+            val direction = tvFocusDirection(event.key)
+                ?: return@onTvTextFieldNavigationKeyEvent false
+
+            pendingDirection = direction
+            true
+        }
+}
+
+@Composable
+fun Modifier.tvFocusProperties(
+    properties: FocusProperties.() -> Unit,
+): Modifier = if (isTelevision) focusProperties(properties) else this
+
+@Composable
+internal expect fun Modifier.onTvTextFieldNavigationKeyEvent(
+    onKeyEvent: (KeyEvent) -> Boolean,
+): Modifier
+
+internal fun shouldInterceptTvTextFieldNavigation(
+    enabled: Boolean,
+    isTelevision: Boolean,
+): Boolean = enabled && isTelevision
+
+internal fun shouldRouteTvTextFieldNavigation(
+    imeVisible: Boolean,
+    imeDismissalPending: Boolean,
+): Boolean = !imeVisible || imeDismissalPending
+
+internal fun tvFocusDirection(key: Key): FocusDirection? = when (key) {
+    Key.DirectionUp -> FocusDirection.Up
+    Key.DirectionDown -> FocusDirection.Down
+    Key.DirectionLeft -> FocusDirection.Left
+    Key.DirectionRight -> FocusDirection.Right
+    else -> null
+}
+
+internal fun isTvActivationKey(key: Key): Boolean = when (key) {
+    Key.DirectionCenter,
+    Key.Enter,
+    Key.NumPadEnter,
+    Key.Spacebar -> true
+    else -> false
 }

--- a/shared/src/commonMain/kotlin/app/utils/PlatformUtils.kt
+++ b/shared/src/commonMain/kotlin/app/utils/PlatformUtils.kt
@@ -32,6 +32,9 @@ enum class Platform(val label: String, val color: Color) {
 /** The platform this build runs on. */
 expect val platform: Platform
 
+/** Whether the current device uses the television UI mode. */
+expect val isTelevision: Boolean
+
 expect val httpClient: HttpClient
 
 /** Media player engines available on the current platform. */

--- a/shared/src/commonTest/kotlin/app/uicomponents/TvFocusTest.kt
+++ b/shared/src/commonTest/kotlin/app/uicomponents/TvFocusTest.kt
@@ -1,0 +1,48 @@
+package app.uicomponents
+
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.input.key.Key
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvFocusTest {
+
+    @Test
+    fun mapsDpadKeysToSpatialFocusDirections() {
+        assertEquals(FocusDirection.Up, tvFocusDirection(Key.DirectionUp))
+        assertEquals(FocusDirection.Down, tvFocusDirection(Key.DirectionDown))
+        assertEquals(FocusDirection.Left, tvFocusDirection(Key.DirectionLeft))
+        assertEquals(FocusDirection.Right, tvFocusDirection(Key.DirectionRight))
+    }
+
+    @Test
+    fun ignoresNonDirectionalKeys() {
+        assertNull(tvFocusDirection(Key.Enter))
+        assertNull(tvFocusDirection(Key.Back))
+    }
+
+    @Test
+    fun installsTextFieldNavigationOnlyOnEnabledTvControls() {
+        assertTrue(shouldInterceptTvTextFieldNavigation(true, true))
+        assertFalse(shouldInterceptTvTextFieldNavigation(true, false))
+        assertFalse(shouldInterceptTvTextFieldNavigation(false, true))
+    }
+
+    @Test
+    fun routesNavigationAfterTheImeIsHiddenOrDismissalStarts() {
+        assertTrue(shouldRouteTvTextFieldNavigation(imeVisible = false, imeDismissalPending = false))
+        assertTrue(shouldRouteTvTextFieldNavigation(imeVisible = true, imeDismissalPending = true))
+        assertFalse(shouldRouteTvTextFieldNavigation(imeVisible = true, imeDismissalPending = false))
+    }
+
+    @Test
+    fun recognizesTvControlActivationKeys() {
+        assertTrue(isTvActivationKey(Key.DirectionCenter))
+        assertTrue(isTvActivationKey(Key.Enter))
+        assertTrue(isTvActivationKey(Key.NumPadEnter))
+        assertFalse(isTvActivationKey(Key.DirectionDown))
+    }
+}

--- a/shared/src/iosMain/kotlin/app/uicomponents/TvFocus.ios.kt
+++ b/shared/src/iosMain/kotlin/app/uicomponents/TvFocus.ios.kt
@@ -1,0 +1,10 @@
+package app.uicomponents
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.KeyEvent
+
+@Composable
+internal actual fun Modifier.onTvTextFieldNavigationKeyEvent(
+    onKeyEvent: (KeyEvent) -> Boolean,
+): Modifier = this

--- a/shared/src/iosMain/kotlin/app/utils/PlatformUtils.ios.kt
+++ b/shared/src/iosMain/kotlin/app/utils/PlatformUtils.ios.kt
@@ -65,6 +65,7 @@ import kotlin.math.roundToLong
 import kotlin.native.ref.WeakReference
 
 actual val platform: Platform = Platform.IOS
+actual val isTelevision: Boolean = false
 
 /* Lazy singleton: a fresh `get()` would mint a new Darwin engine (and NSURLSession) on every
  * access (the GIF grid does this per-tile per-scroll), and iOS throttles new sessions, so Klipy


### PR DESCRIPTION
## Summary

- Fix D-pad focus transfer from Android TV text fields to reproduced neighboring controls.
- Give TV dialogs and menus deterministic initial focus and directional focus order.
- Make popup actions respond to D-pad Center/Enter.

## Reproduced issues

These failures were reproduced on an Android TV API 36 emulator before the changes:

| Surface | Failure |
| --- | --- |
| Network URL dialog | The URL editor did not reliably receive initial focus, and Down could not reach Done. |
| Home username/room fields | Down stayed in the current editor instead of moving to the next field. |
| Shared playlist: Add URL | The dialog opened without a focused node, and Down could not reach Done. |
| Seek To | Left stayed in seconds instead of moving to minutes. |
| Subtitle search | Right stayed in the search editor because the search action was not a TV focus target. |
| Managed room name | Down stayed in the editor instead of reaching the actions. |
| Trusted domains | Down stayed in the editor instead of reaching the actions. |
| Room overflow | Opening the three-dot menu left focus behind the popup, so Leave room was unreachable. |

## Behavior

- Text fields have explicit directional destinations for the affected TV workflows.
- Dialog action controls are TV focus targets and support D-pad Center/Enter.
- The room overflow popup takes focus at its first available action and traverses visible actions in order.
- TV-specific behavior is isolated behind shared expect/actual focus utilities; non-TV behavior remains unchanged.

## Verification

- `./gradlew :shared:testAndroidHostTest :shared:compileAndroidMain`
- `./gradlew :shared:iosSimulatorArm64Test`
- `./gradlew :androidApp:assembleExoOnlyDebug -PexoOnly=true`
- Android TV API 36 emulator: verified initial focus and D-pad traversal for the reproduced dialogs and controls.
- Android phone API 36 emulator: verified no forced initial focus on the join screen or room overflow, touch-operated overflow actions, and URL-field touch focus with the software keyboard.
- Paired Google TV Streamer: installed and exercised the accessibility build.
- Host tests cover D-pad interception decisions and activation keys.

Media picking and pre-download are intentionally excluded and will be submitted separately.
