### PR TITLE
Add locked-screen hardware keyboard chat

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
         compileSdk { version = release(providers.gradleProperty("android.compileSdk").get().toInt()) }
         minSdk = providers.gradleProperty("android.minSdk").get().toInt()
         androidResources { enable = true }
+        withHostTest {}
     }
 
     // Activating iOS targets (iosMain)

--- a/shared/src/androidMain/kotlin/app/room/ui/tabs/LockedChatKeyboardInput.android.kt
+++ b/shared/src/androidMain/kotlin/app/room/ui/tabs/LockedChatKeyboardInput.android.kt
@@ -1,0 +1,49 @@
+package app.room.ui.tabs
+
+import android.view.KeyEvent
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+
+internal actual fun Modifier.lockedChatKeyboardInput(
+    enabled: Boolean,
+    onText: (String) -> Unit,
+    onBackspace: () -> Unit,
+    onSend: () -> Unit,
+): Modifier {
+    if (!enabled) return this
+
+    return onPreviewKeyEvent { event ->
+        val nativeEvent = event.nativeKeyEvent
+        if (nativeEvent.action != KeyEvent.ACTION_DOWN) {
+            return@onPreviewKeyEvent false
+        }
+
+        when (nativeEvent.keyCode) {
+            KeyEvent.KEYCODE_ENTER,
+            KeyEvent.KEYCODE_NUMPAD_ENTER -> {
+                onSend()
+                true
+            }
+
+            KeyEvent.KEYCODE_DEL -> {
+                onBackspace()
+                true
+            }
+
+            else -> {
+                if (nativeEvent.isMetaPressed ||
+                    (nativeEvent.isCtrlPressed && !nativeEvent.isAltPressed)
+                ) {
+                    return@onPreviewKeyEvent false
+                }
+                val codePoint = nativeEvent.unicodeChar
+                if (codePoint <= 0 || Character.isISOControl(codePoint)) {
+                    false
+                } else {
+                    onText(String(Character.toChars(codePoint)))
+                    true
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/app/room/ui/tabs/LockedChatKeyboardInput.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/tabs/LockedChatKeyboardInput.kt
@@ -1,0 +1,35 @@
+package app.room.ui.tabs
+
+import androidx.compose.ui.Modifier
+
+internal expect fun Modifier.lockedChatKeyboardInput(
+    enabled: Boolean,
+    onText: (String) -> Unit,
+    onBackspace: () -> Unit,
+    onSend: () -> Unit,
+): Modifier
+
+internal fun appendLockedChatText(
+    draft: String,
+    text: String,
+    maxLength: Int,
+): String = (draft + text).take(maxLength.coerceAtLeast(1))
+
+internal fun removeLockedChatCharacter(draft: String): String {
+    if (draft.isEmpty()) return draft
+    val characterCount = if (
+        draft.length >= 2 &&
+        draft.last().isLowSurrogate() &&
+        draft[draft.lastIndex - 1].isHighSurrogate()
+    ) {
+        2
+    } else {
+        1
+    }
+    return draft.dropLast(characterCount)
+}
+
+internal fun lockedChatMessageToSend(
+    draft: String,
+    maxLength: Int,
+): String? = draft.take(maxLength.coerceAtLeast(1)).takeIf { it.isNotBlank() }

--- a/shared/src/commonMain/kotlin/app/room/ui/tabs/RoomUnlockableLayout.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/tabs/RoomUnlockableLayout.kt
@@ -1,11 +1,13 @@
 package app.room.ui.tabs
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -16,6 +18,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ripple
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -26,8 +29,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.LocalRoomUiState
 import app.LocalRoomViewmodel
@@ -44,13 +52,42 @@ fun RoomUnlockableLayout() {
 
     val lockedMode by cardController.tabLock.collectAsState()
     val isInPipMode by viewmodel.uiState.hasEnteredPipMode.collectAsState()
+    val isChatSupported by viewmodel.protocol.supportsChat.collectAsState()
 
     if (lockedMode) {
         var unlockButtonVisibility by remember { mutableStateOf(true) }
+        var chatDraft by remember { mutableStateOf("") }
+        val keyboardFocusRequester = remember { FocusRequester() }
+        val softwareKeyboardController = LocalSoftwareKeyboardController.current
+        val chatEnabled = isChatSupported && !viewmodel.isSoloMode
+        val maxChatLength = viewmodel.session.roomFeatures.maxChatMessageLength.coerceAtLeast(1)
+
+        LaunchedEffect(chatEnabled) {
+            if (chatEnabled) {
+                softwareKeyboardController?.hide()
+                runCatching { keyboardFocusRequester.requestFocus() }
+            }
+        }
 
         Box(
             Modifier.fillMaxSize()
                 .padding(top = 10.dp, end = 74.dp)
+                .focusRequester(keyboardFocusRequester)
+                .lockedChatKeyboardInput(
+                    enabled = chatEnabled,
+                    onText = { text ->
+                        chatDraft = appendLockedChatText(chatDraft, text, maxChatLength)
+                    },
+                    onBackspace = {
+                        chatDraft = removeLockedChatCharacter(chatDraft)
+                    },
+                    onSend = {
+                        lockedChatMessageToSend(chatDraft, maxChatLength)?.let {
+                            viewmodel.dispatcher.sendMessage(it)
+                        }
+                        chatDraft = ""
+                    },
+                )
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
@@ -59,6 +96,22 @@ fun RoomUnlockableLayout() {
                     }
             )
         ) {
+            if (chatDraft.isNotEmpty()) {
+                Text(
+                    text = chatDraft,
+                    color = Color.White,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(16.dp)
+                        .fillMaxWidth(0.75f)
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(Color.DarkGray.copy(alpha = 0.9f))
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                )
+            }
+
             /** Unlock Card */
             if (unlockButtonVisibility && !isInPipMode) {
                 LaunchedEffect(null) {

--- a/shared/src/commonTest/kotlin/app/room/ui/tabs/LockedChatKeyboardInputTest.kt
+++ b/shared/src/commonTest/kotlin/app/room/ui/tabs/LockedChatKeyboardInputTest.kt
@@ -1,0 +1,30 @@
+package app.room.ui.tabs
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LockedChatKeyboardInputTest {
+
+    @Test
+    fun appendsTextWithoutExceedingTheServerLimit() {
+        assertEquals(
+            "hello",
+            appendLockedChatText(draft = "hel", text = "lo world", maxLength = 5),
+        )
+    }
+
+    @Test
+    fun backspaceRemovesAWholeUnicodeCodePoint() {
+        assertEquals(
+            "a",
+            removeLockedChatCharacter("a\uD83D\uDE00"),
+        )
+    }
+
+    @Test
+    fun sendRejectsBlankDraftsAndCapsThePayload() {
+        assertNull(lockedChatMessageToSend("   ", maxLength = 150))
+        assertEquals("hello", lockedChatMessageToSend("hello world", maxLength = 5))
+    }
+}

--- a/shared/src/iosMain/kotlin/app/room/ui/tabs/LockedChatKeyboardInput.ios.kt
+++ b/shared/src/iosMain/kotlin/app/room/ui/tabs/LockedChatKeyboardInput.ios.kt
@@ -1,0 +1,10 @@
+package app.room.ui.tabs
+
+import androidx.compose.ui.Modifier
+
+internal actual fun Modifier.lockedChatKeyboardInput(
+    enabled: Boolean,
+    onText: (String) -> Unit,
+    onBackspace: () -> Unit,
+    onSend: () -> Unit,
+): Modifier = this


### PR DESCRIPTION
One of my favorite features in syncplay was MPV's chat functionality. It let you chat with minimal overlay within the player.

## Summary

- allow a connected hardware keyboard to type chat messages while the room UI is locked
- show a compact two-line draft without creating a text editor or opening the software keyboard
- support Backspace and Enter using the existing chat length limit and dispatcher
- immediately dismiss an active IME and transfer focus to the locked non-editor surface

## Behavior

- printable hardware key events append to the locked draft
- Backspace removes one complete Unicode code point
- Enter rejects blank drafts, sends valid text, and clears the draft
- Ctrl/Meta shortcuts and non-printable remote keys continue through normal handling
- iOS remains unchanged through a no-op platform implementation

## Verification

- isolated Android host tests cover length limits, blank messages, and surrogate-pair Backspace behavior
- `./gradlew :shared:testAndroidHostTest :shared:compileAndroidMain`
- `./gradlew :shared:iosSimulatorArm64Test`
- `./gradlew :androidApp:assembleExoOnlyDebug -PexoOnly=true`
- Android TV API 36 emulator: exercised hardware text entry, Backspace, and Enter while locked
- Android phone API 36 emulator: verified lock does not open the software keyboard, hardware key events update and send the compact draft, and the existing touch reveal/unlock flow remains functional
- locking while the chat IME was visible, followed immediately by a raw hardware key, left `mInputShown=false`, removed the input connection, and updated only the compact locked draft
