### PR TITLE
Fix fading chat message cancellation

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
         compileSdk { version = release(providers.gradleProperty("android.compileSdk").get().toInt()) }
         minSdk = providers.gradleProperty("android.minSdk").get().toInt()
         androidResources { enable = true }
+        withHostTest {}
     }
 
     // Activating iOS targets (iosMain)

--- a/shared/src/commonMain/kotlin/app/room/ui/chat/RoomFadingChatLayout.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/chat/RoomFadingChatLayout.kt
@@ -25,8 +25,24 @@ import app.LocalChatPalette
 import app.LocalRoomViewmodel
 import app.preferences.Preferences.MSG_FADING_DURATION
 import app.preferences.watchPref
+import app.room.models.Message
 import kotlinx.coroutines.delay
 
+internal data class FadingMessagePresentation(
+    val message: Message? = null,
+    val visible: Boolean = false,
+)
+
+internal fun nextFadingMessagePresentation(
+    current: FadingMessagePresentation,
+    latest: Message?,
+): FadingMessagePresentation {
+    return if (latest != null && !latest.isMainUser && !latest.seen) {
+        FadingMessagePresentation(message = latest, visible = true)
+    } else {
+        current.copy(visible = false)
+    }
+}
 
 /** Briefly shows the latest unseen non-self chat message when the HUD is hidden, then fades it out. */
 @Composable
@@ -40,17 +56,20 @@ fun FadingMessageLayout() {
     val palette = LocalChatPalette.current
 
     if (!isHUDVisible) {
-        var visibility by remember { mutableStateOf(false) }
+        var presentation by remember { mutableStateOf(FadingMessagePresentation()) }
         val msgs by viewmodel.session.messageSequence.collectAsState()
-        LaunchedEffect(msgs.size) {
-            if (msgs.isNotEmpty()) {
-                val lastMsg = msgs.last()
-
-                if (!lastMsg.isMainUser && !lastMsg.seen) {
-                    visibility = true
-                    delay(fadingTimeout.value.toLong() * 1000L)
-                    visibility = false
+        LaunchedEffect(msgs) {
+            presentation = nextFadingMessagePresentation(presentation, msgs.lastOrNull())
+            val displayedMessage = presentation.message
+            if (presentation.visible) {
+                delay(fadingTimeout.value.toLong() * 1000L)
+                if (presentation.message === displayedMessage) {
+                    presentation = presentation.copy(visible = false)
                 }
+            }
+            delay(FADE_OUT_MILLIS.toLong())
+            if (presentation.message === displayedMessage && !presentation.visible) {
+                presentation = FadingMessagePresentation()
             }
         }
 
@@ -58,21 +77,25 @@ fun FadingMessageLayout() {
             modifier = Modifier.fillMaxWidth().padding(24.dp),
             horizontalAlignment = Alignment.Start
         ) {
-            AnimatedVisibility(
-                enter = fadeIn(animationSpec = keyframes { durationMillis = 100 }),
-                exit = fadeOut(animationSpec = keyframes { durationMillis = 500 }),
-                visible = visibility,
-            ) {
-                Text(
-                    modifier = Modifier
-                        .fillMaxWidth(0.8f)
-                        .focusable(false),
-                    overflow = TextOverflow.Ellipsis,
-                    text = msgs.last().factorize(palette),
-                    lineHeight = if (isInPiPMode) 9.sp else 15.sp,
-                    fontSize = if (isInPiPMode) 8.sp else 13.sp
-                )
+            presentation.message?.let { message ->
+                AnimatedVisibility(
+                    enter = fadeIn(animationSpec = keyframes { durationMillis = 100 }),
+                    exit = fadeOut(animationSpec = keyframes { durationMillis = FADE_OUT_MILLIS }),
+                    visible = presentation.visible,
+                ) {
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth(0.8f)
+                            .focusable(false),
+                        overflow = TextOverflow.Ellipsis,
+                        text = message.factorize(palette),
+                        lineHeight = if (isInPiPMode) 9.sp else 15.sp,
+                        fontSize = if (isInPiPMode) 8.sp else 13.sp
+                    )
+                }
             }
         }
     }
 }
+
+private const val FADE_OUT_MILLIS = 500

--- a/shared/src/commonTest/kotlin/app/room/ui/chat/RoomFadingChatLayoutTest.kt
+++ b/shared/src/commonTest/kotlin/app/room/ui/chat/RoomFadingChatLayoutTest.kt
@@ -1,0 +1,34 @@
+package app.room.ui.chat
+
+import app.room.models.Message
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class RoomFadingChatLayoutTest {
+
+    @Test
+    fun ineligibleMessageFadesTheExistingSnapshotWithoutReplacingIt() {
+        val incoming = Message(sender = "friend", content = "hello")
+        val visible = nextFadingMessagePresentation(FadingMessagePresentation(), incoming)
+
+        val selfMessage = Message(sender = "me", content = "reply", isMainUser = true)
+        val fading = nextFadingMessagePresentation(visible, selfMessage)
+
+        assertSame(incoming, fading.message)
+        assertFalse(fading.visible)
+    }
+
+    @Test
+    fun unseenIncomingMessageReplacesTheSnapshotAndRestartsVisibility() {
+        val first = Message(sender = "one", content = "first")
+        val second = Message(sender = "two", content = "second")
+        val current = FadingMessagePresentation(message = first, visible = false)
+
+        val next = nextFadingMessagePresentation(current, second)
+
+        assertSame(second, next.message)
+        assertTrue(next.visible)
+    }
+}


### PR DESCRIPTION
## Summary

- keep a stable snapshot of the incoming message being presented while the HUD is hidden
- fade the existing snapshot out when a self, seen, or otherwise ineligible message arrives
- clear the snapshot only after the exit animation completes
- restart the display timeout when a new eligible incoming message arrives

## Reproduced bug

The layout rendered `messageSequence.last()` directly while its visibility coroutine was keyed only by message count. A later self or seen message could therefore replace the text under an active fade and cancel the intended incoming-message presentation.

## Verification

- isolated tests confirm an ineligible message hides without replacing the active snapshot
- isolated tests confirm a new unseen incoming message replaces the snapshot and restarts visibility
- `./gradlew :shared:testAndroidHostTest :shared:compileAndroidMain`
- `./gradlew :shared:iosSimulatorArm64Test`
- `./gradlew :androidApp:assembleExoOnlyDebug -PexoOnly=true`
- Android phone API 36 emulator: verified normal room rendering and ordinary touch chat focus with the software keyboard
