### PR TITLE
Add Android TV local video picker

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
         compileSdk { version = release(providers.gradleProperty("android.compileSdk").get().toInt()) }
         minSdk = providers.gradleProperty("android.minSdk").get().toInt()
         androidResources { enable = true }
+        withHostTest {}
     }
 
     // Activating iOS targets (iosMain)

--- a/shared/src/androidMain/AndroidManifest.xml
+++ b/shared/src/androidMain/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/shared/src/androidMain/kotlin/app/room/ui/bottombar/TvLocalVideoPicker.android.kt
+++ b/shared/src/androidMain/kotlin/app/room/ui/bottombar/TvLocalVideoPicker.android.kt
@@ -1,0 +1,264 @@
+package app.room.ui.bottombar
+
+import android.Manifest
+import android.content.ContentUris
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.MediaStore
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Movie
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import app.uicomponents.SyncplayPopup
+import io.github.vinceglb.filekit.PlatformFile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.stringResource
+import syncplaymobile.shared.generated.resources.Res
+import syncplaymobile.shared.generated.resources.cancel
+import syncplaymobile.shared.generated.resources.room_addmedia_offline_tv_empty
+import syncplaymobile.shared.generated.resources.room_addmedia_offline_tv_permission
+import syncplaymobile.shared.generated.resources.room_addmedia_offline_tv_title
+
+@Composable
+internal actual fun rememberTvLocalVideoPickerLauncher(
+    onVideoSelected: (PlatformFile) -> Unit,
+): (() -> Unit)? {
+    val context = LocalContext.current
+    if (!context.isTelevisionDevice()) return null
+
+    val scope = rememberCoroutineScope()
+    val firstVideoFocusRequester = remember { FocusRequester() }
+    var dialogOpen by remember { mutableStateOf(false) }
+    var loading by remember { mutableStateOf(false) }
+    var permissionDenied by remember { mutableStateOf(false) }
+    var videos by remember { mutableStateOf(emptyList<TvVideo>()) }
+
+    fun loadVideos() {
+        scope.launch {
+            loading = true
+            permissionDenied = false
+            videos = withContext(Dispatchers.IO) { context.queryLocalVideos() }
+            loading = false
+            dialogOpen = true
+        }
+    }
+
+    val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_VIDEO
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) {
+            loadVideos()
+        } else {
+            permissionDenied = true
+            loading = false
+            dialogOpen = true
+        }
+    }
+
+    val launchPicker: () -> Unit = {
+        if (ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED) {
+            loadVideos()
+        } else {
+            permissionLauncher.launch(permission)
+        }
+    }
+
+    LaunchedEffect(dialogOpen, videos) {
+        if (dialogOpen && videos.isNotEmpty()) {
+            delay(100)
+            firstVideoFocusRequester.requestFocus()
+        }
+    }
+
+    SyncplayPopup(
+        dialogOpen = dialogOpen,
+        widthPercent = 0.72f,
+        heightPercent = 0.82f,
+        onDismiss = { dialogOpen = false },
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(Res.string.room_addmedia_offline_tv_title),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            when {
+                loading -> {
+                    CircularProgressIndicator()
+                }
+
+                permissionDenied -> {
+                    Text(
+                        text = stringResource(Res.string.room_addmedia_offline_tv_permission),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+
+                videos.isEmpty() -> {
+                    Text(
+                        text = stringResource(Res.string.room_addmedia_offline_tv_empty),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxWidth().weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        itemsIndexed(videos, key = { _, video -> video.uri }) { index, video ->
+                            Button(
+                                modifier = Modifier.fillMaxWidth()
+                                    .then(
+                                        if (index == 0) {
+                                            Modifier.focusRequester(firstVideoFocusRequester)
+                                        } else {
+                                            Modifier
+                                        }
+                                    ),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                                    contentColor = MaterialTheme.colorScheme.onSurface,
+                                ),
+                                onClick = {
+                                    dialogOpen = false
+                                    onVideoSelected(PlatformFile(video.uri))
+                                },
+                            ) {
+                                Icon(Icons.Filled.Movie, contentDescription = null)
+                                Spacer(Modifier.width(12.dp))
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    horizontalAlignment = Alignment.Start,
+                                ) {
+                                    Text(
+                                        text = video.name,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                    Text(
+                                        text = video.details,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
+            TextButton(onClick = { dialogOpen = false }) {
+                Text(stringResource(Res.string.cancel))
+            }
+        }
+    }
+
+    return launchPicker
+}
+
+private data class TvVideo(
+    val uri: String,
+    val name: String,
+    val durationMs: Long,
+    val sizeBytes: Long,
+) {
+    val details: String
+        get() = "${formatDuration(durationMs)} - ${formatFileSize(sizeBytes)}"
+}
+
+private fun Context.queryLocalVideos(): List<TvVideo> {
+    val collection = MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+    val projection = arrayOf(
+        MediaStore.Video.Media._ID,
+        MediaStore.Video.Media.DISPLAY_NAME,
+        MediaStore.Video.Media.DURATION,
+        MediaStore.Video.Media.SIZE,
+    )
+
+    return contentResolver.query(
+        collection,
+        projection,
+        null,
+        null,
+        "${MediaStore.Video.Media.DATE_MODIFIED} DESC",
+    )?.use { cursor ->
+        val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media._ID)
+        val nameColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media.DISPLAY_NAME)
+        val durationColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media.DURATION)
+        val sizeColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media.SIZE)
+
+        buildList {
+            while (cursor.moveToNext()) {
+                add(
+                    TvVideo(
+                        uri = ContentUris.withAppendedId(collection, cursor.getLong(idColumn)).toString(),
+                        name = cursor.getString(nameColumn) ?: "Unnamed video",
+                        durationMs = cursor.getLong(durationColumn),
+                        sizeBytes = cursor.getLong(sizeColumn),
+                    )
+                )
+            }
+        }
+    }.orEmpty()
+}
+
+private fun formatDuration(durationMs: Long): String {
+    val totalSeconds = durationMs.coerceAtLeast(0L) / 1_000L
+    val minutes = totalSeconds / 60L
+    val seconds = totalSeconds % 60L
+    return "$minutes:${seconds.toString().padStart(2, '0')}"
+}
+
+private fun formatFileSize(sizeBytes: Long): String {
+    val megabytes = sizeBytes.coerceAtLeast(0L) / (1024.0 * 1024.0)
+    return "${(megabytes * 10).toLong() / 10.0} MB"
+}

--- a/shared/src/androidMain/kotlin/app/room/ui/bottombar/TvMediaDevice.android.kt
+++ b/shared/src/androidMain/kotlin/app/room/ui/bottombar/TvMediaDevice.android.kt
@@ -1,0 +1,11 @@
+package app.room.ui.bottombar
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.content.res.Configuration
+
+internal fun Context.isTelevisionDevice(): Boolean {
+    val uiModeIsTelevision = resources.configuration.uiMode and
+        Configuration.UI_MODE_TYPE_MASK == Configuration.UI_MODE_TYPE_TELEVISION
+    return uiModeIsTelevision || packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
+}

--- a/shared/src/commonMain/composeResources/values-en/strings.xml
+++ b/shared/src/commonMain/composeResources/values-en/strings.xml
@@ -177,6 +177,10 @@
     <string name="room_button_desc_more">More Settings</string>
     <string name="room_addmedia_offline">From storage (system picker)</string>
     <string name="room_addmedia_offline_system">From storage (custom picker)</string>
+    <string name="room_addmedia_offline_tv">From storage</string>
+    <string name="room_addmedia_offline_tv_title">Choose a local video</string>
+    <string name="room_addmedia_offline_tv_permission">Video access is required to browse local files.</string>
+    <string name="room_addmedia_offline_tv_empty">No local videos found.</string>
     <string name="room_addmedia_online">From a network URL</string>
     <string name="room_addmedia_online_details">Load Media from a network URL</string>
     <string name="room_addmedia_online_popup_subtext">Make sure to provide direct links (for example: www.example.com/video.mp4). YouTube and other media streaming services are not supported yet.</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -177,6 +177,10 @@
     <string name="room_button_desc_more">More Settings</string>
     <string name="room_addmedia_offline">From storage (system picker)</string>
     <string name="room_addmedia_offline_system">From storage (custom picker)</string>
+    <string name="room_addmedia_offline_tv">From storage</string>
+    <string name="room_addmedia_offline_tv_title">Choose a local video</string>
+    <string name="room_addmedia_offline_tv_permission">Video access is required to browse local files.</string>
+    <string name="room_addmedia_offline_tv_empty">No local videos found.</string>
     <string name="room_addmedia_online">From a network URL</string>
     <string name="room_addmedia_online_details">Load Media from a network URL</string>
     <string name="room_addmedia_online_popup_subtext">Make sure to provide direct links (for example: www.example.com/video.mp4). YouTube and other media streaming services are not supported yet.</string>

--- a/shared/src/commonMain/kotlin/app/room/ui/bottombar/RoomMediaAddButton.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/bottombar/RoomMediaAddButton.kt
@@ -83,6 +83,7 @@ import syncplaymobile.shared.generated.resources.Res
 import syncplaymobile.shared.generated.resources.done
 import syncplaymobile.shared.generated.resources.room_addmedia_offline
 import syncplaymobile.shared.generated.resources.room_addmedia_offline_system
+import syncplaymobile.shared.generated.resources.room_addmedia_offline_tv
 import syncplaymobile.shared.generated.resources.room_addmedia_online
 import syncplaymobile.shared.generated.resources.room_addmedia_online_details
 import syncplaymobile.shared.generated.resources.room_addmedia_online_popup_subtext
@@ -106,6 +107,12 @@ fun RoomMediaAddButton(popupStateAddMedia: MutableState<Boolean>) {
             }
             showPopup = false
         }
+    }
+    val tvVideoPicker = rememberTvLocalVideoPickerLauncher { file ->
+        viewmodel.viewModelScope.launch {
+            viewmodel.player.injectVideoFile(file)
+        }
+        showPopup = false
     }
 
     // iOS FileKit picker race (FileKit #575): launching a picker while a Compose modal
@@ -158,34 +165,7 @@ fun RoomMediaAddButton(popupStateAddMedia: MutableState<Boolean>) {
                 font = jostFont
             )
 
-            // From storage (system picker): FileKit's default ACTION_OPEN_DOCUMENT SAF picker,
-            // filtered by MIME types derived from vidExs on Android; UIDocumentPickerViewController on iOS.
-            DropdownMenuItem(
-                text = {
-                    Row(verticalAlignment = CenterVertically) {
-                        FlexibleIcon(
-                            icon = Icons.Filled.FolderOpen,
-                            size = ROOM_ICON_SIZE,
-                            shadowColors = listOf(Color.Black)
-                        ) {}
-                        Spacer(Modifier.width(8.dp))
-                        Text(
-                            color = Color.LightGray,
-                            text = stringResource(Res.string.room_addmedia_offline),
-                        )
-                    }
-                },
-                onClick = {
-                    launchVideoPickerAfterDismiss = true
-                    showPopup = false
-                }
-            )
-
-            // From storage (custom picker): Android only. Fires ACTION_GET_CONTENT in
-            // Intent.createChooser() so any installed file manager / SMB / cloud app can be picked.
-            // Covers SMB DocumentsProviders whose opaque MIMEs FileKit's extension filter rejects.
-            // iOS has no chooser API, so the item is hidden there.
-            if (platform == Platform.Android) {
+            if (shouldUseTvLocalVideoPicker(tvVideoPicker != null)) {
                 DropdownMenuItem(
                     text = {
                         Row(verticalAlignment = CenterVertically) {
@@ -197,21 +177,67 @@ fun RoomMediaAddButton(popupStateAddMedia: MutableState<Boolean>) {
                             Spacer(Modifier.width(8.dp))
                             Text(
                                 color = Color.LightGray,
-                                text = stringResource(Res.string.room_addmedia_offline_system),
+                                text = stringResource(Res.string.room_addmedia_offline_tv),
                             )
                         }
                     },
                     onClick = {
                         showPopup = false
-                        platformCallback.launchSystemFilePicker { uri ->
-                            if (uri != null) {
-                                viewmodel.viewModelScope.launch {
-                                    viewmodel.player.injectVideoFile(PlatformFile(uri))
+                        tvVideoPicker?.invoke()
+                    }
+                )
+            } else {
+                // FileKit's ACTION_OPEN_DOCUMENT picker on Android and UIDocumentPicker on iOS.
+                DropdownMenuItem(
+                    text = {
+                        Row(verticalAlignment = CenterVertically) {
+                            FlexibleIcon(
+                                icon = Icons.Filled.FolderOpen,
+                                size = ROOM_ICON_SIZE,
+                                shadowColors = listOf(Color.Black)
+                            ) {}
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                color = Color.LightGray,
+                                text = stringResource(Res.string.room_addmedia_offline),
+                            )
+                        }
+                    },
+                    onClick = {
+                        launchVideoPickerAfterDismiss = true
+                        showPopup = false
+                    }
+                )
+
+                // Android chooser fallback for third-party file managers and cloud providers.
+                if (platform == Platform.Android) {
+                    DropdownMenuItem(
+                        text = {
+                            Row(verticalAlignment = CenterVertically) {
+                                FlexibleIcon(
+                                    icon = Icons.Filled.FolderOpen,
+                                    size = ROOM_ICON_SIZE,
+                                    shadowColors = listOf(Color.Black)
+                                ) {}
+                                Spacer(Modifier.width(8.dp))
+                                Text(
+                                    color = Color.LightGray,
+                                    text = stringResource(Res.string.room_addmedia_offline_system),
+                                )
+                            }
+                        },
+                        onClick = {
+                            showPopup = false
+                            platformCallback.launchSystemFilePicker { uri ->
+                                if (uri != null) {
+                                    viewmodel.viewModelScope.launch {
+                                        viewmodel.player.injectVideoFile(PlatformFile(uri))
+                                    }
                                 }
                             }
                         }
-                    }
-                )
+                    )
+                }
             }
 
             //From network URL

--- a/shared/src/commonMain/kotlin/app/room/ui/bottombar/TvLocalVideoPicker.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/bottombar/TvLocalVideoPicker.kt
@@ -1,0 +1,13 @@
+package app.room.ui.bottombar
+
+import androidx.compose.runtime.Composable
+import io.github.vinceglb.filekit.PlatformFile
+
+@Composable
+internal expect fun rememberTvLocalVideoPickerLauncher(
+    onVideoSelected: (PlatformFile) -> Unit,
+): (() -> Unit)?
+
+internal fun shouldUseTvLocalVideoPicker(
+    launcherAvailable: Boolean,
+): Boolean = launcherAvailable

--- a/shared/src/commonTest/kotlin/app/room/ui/bottombar/TvLocalVideoPickerTest.kt
+++ b/shared/src/commonTest/kotlin/app/room/ui/bottombar/TvLocalVideoPickerTest.kt
@@ -1,0 +1,14 @@
+package app.room.ui.bottombar
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvLocalVideoPickerTest {
+
+    @Test
+    fun usesLocalPickerOnlyWhenPlatformLauncherIsAvailable() {
+        assertTrue(shouldUseTvLocalVideoPicker(launcherAvailable = true))
+        assertFalse(shouldUseTvLocalVideoPicker(launcherAvailable = false))
+    }
+}

--- a/shared/src/iosMain/kotlin/app/room/ui/bottombar/TvLocalVideoPicker.ios.kt
+++ b/shared/src/iosMain/kotlin/app/room/ui/bottombar/TvLocalVideoPicker.ios.kt
@@ -1,0 +1,9 @@
+package app.room.ui.bottombar
+
+import androidx.compose.runtime.Composable
+import io.github.vinceglb.filekit.PlatformFile
+
+@Composable
+internal actual fun rememberTvLocalVideoPickerLauncher(
+    onVideoSelected: (PlatformFile) -> Unit,
+): (() -> Unit)? = null


### PR DESCRIPTION
## Summary

- Replace Android TV's unavailable system document-picker path with an in-app MediaStore video picker.
- Request video-library permission and display local videos in a D-pad-friendly list.
- Keep the existing platform picker behavior on non-TV Android devices and iOS.

## Reproduced issue

Selecting a local file on both the Android TV API 36 emulator and a physical Google TV Streamer opened the platform document flow and reported: `You don't have an app that can do this`.

Android TV images do not necessarily include a DocumentsProvider that can satisfy the existing file-picker intent. This change queries videos through MediaStore instead of requiring another installed app.

## Verification

- `./gradlew :shared:testAndroidHostTest :shared:compileAndroidMain`
- `./gradlew :shared:iosSimulatorArm64Test`
- `./gradlew :androidApp:assembleExoOnlyDebug -PexoOnly=true`
- Android TV API 36 emulator: opened the media menu, completed the video permission flow, and rendered the in-app picker.
- Android phone API 36 emulator: verified the unchanged system picker, custom picker, and network URL options; no TV-only picker or permission flow was shown.
- Physical Google TV Streamer: reproduced the missing document-provider failure that this picker replaces.
- Host tests cover picker selection policy.

Pre-download behavior is intentionally excluded and submitted separately. No APKs, recordings, screenshots, or other build artifacts are attached.
