### PR TITLE
Add Android TV media pre-download

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
         compileSdk { version = release(providers.gradleProperty("android.compileSdk").get().toInt()) }
         minSdk = providers.gradleProperty("android.minSdk").get().toInt()
         androidResources { enable = true }
+        withHostTest {}
     }
 
     // Activating iOS targets (iosMain)

--- a/shared/src/androidMain/kotlin/app/room/ui/bottombar/TvVideoPreDownloader.android.kt
+++ b/shared/src/androidMain/kotlin/app/room/ui/bottombar/TvVideoPreDownloader.android.kt
@@ -1,0 +1,338 @@
+package app.room.ui.bottombar
+
+import android.content.ContentValues
+import android.content.Context
+import android.content.pm.PackageManager
+import android.content.res.Configuration
+import android.net.Uri
+import android.os.Build
+import android.os.ParcelFileDescriptor
+import android.provider.MediaStore
+import android.webkit.MimeTypeMap
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+import java.net.URLDecoder
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.coroutines.coroutineContext
+
+@Composable
+internal actual fun rememberTvVideoPreDownloader(
+    onProgress: (Float?) -> Unit,
+    onComplete: (String) -> Unit,
+    onError: (String) -> Unit,
+): ((String) -> Unit)? {
+    val context = LocalContext.current
+    if (!context.isTelevisionForPreDownload() || Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
+
+    val scope = rememberCoroutineScope()
+    val currentOnProgress by rememberUpdatedState(onProgress)
+    val currentOnComplete by rememberUpdatedState(onComplete)
+    val currentOnError by rememberUpdatedState(onError)
+
+    return remember(context, scope) {
+        { url ->
+            scope.launch {
+                runCatching {
+                    withContext(Dispatchers.IO) {
+                        TvParallelDownloader.download(
+                            context = context,
+                            url = url,
+                            onProgress = { progress ->
+                                scope.launch { currentOnProgress(progress) }
+                            },
+                        )
+                    }
+                }.onSuccess(currentOnComplete)
+                    .onFailure { error ->
+                        currentOnError(error.message ?: "Download failed")
+                    }
+            }
+        }
+    }
+}
+
+private fun Context.isTelevisionForPreDownload(): Boolean {
+    val uiModeIsTelevision = resources.configuration.uiMode and
+        Configuration.UI_MODE_TYPE_MASK == Configuration.UI_MODE_TYPE_TELEVISION
+    return uiModeIsTelevision || packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
+}
+
+private object TvParallelDownloader {
+    private const val PARALLEL_PARTS = 4
+    private const val PARALLEL_MIN_BYTES = 4L * 1024L * 1024L
+    private const val BUFFER_SIZE = 128 * 1024
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(20, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .followRedirects(true)
+        .followSslRedirects(true)
+        .build()
+
+    suspend fun download(
+        context: Context,
+        url: String,
+        onProgress: (Float?) -> Unit,
+    ): String {
+        val probe = probe(url)
+        onProgress(if (probe.totalBytes != null) 0f else null)
+        if (probe.supportsRanges &&
+            probe.totalBytes != null &&
+            probe.totalBytes >= PARALLEL_MIN_BYTES
+        ) {
+            runCatching {
+                downloadParallelToMediaStore(context, url, probe, onProgress)
+            }.getOrElse {
+                if (it is CancellationException) throw it
+                coroutineContext.ensureActive()
+                onProgress(0f)
+                downloadSequentialToMediaStore(context, url, probe, onProgress)
+            }
+        } else {
+            downloadSequentialToMediaStore(context, url, probe, onProgress)
+        }
+        return probe.fileName
+    }
+
+    private fun probe(url: String): ProbeResult {
+        val request = Request.Builder()
+            .url(url)
+            .header("Range", "bytes=0-0")
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("Server returned HTTP ${response.code}")
+            }
+
+            val totalBytes = response.header("Content-Range")
+                ?.substringAfterLast('/')
+                ?.toLongOrNull()
+                ?: response.body.contentLength().takeIf { it > 0L && response.code == 200 }
+            return ProbeResult(
+                totalBytes = totalBytes,
+                supportsRanges = response.code == 206 && totalBytes != null,
+                fileName = response.downloadFileName(url),
+                mimeType = response.header("Content-Type")
+                    ?.substringBefore(';')
+                    ?.takeIf { it.isNotBlank() }
+                    ?: "video/*",
+            )
+        }
+    }
+
+    private suspend fun downloadParallelToMediaStore(
+        context: Context,
+        url: String,
+        probe: ProbeResult,
+        onProgress: (Float?) -> Unit,
+    ) {
+        val totalBytes = requireNotNull(probe.totalBytes)
+        writePendingVideo(context, probe.fileName, probe.mimeType) { uri ->
+            val descriptor = context.contentResolver.openFileDescriptor(uri, "rw")
+                ?: throw IOException("Could not open the downloaded video")
+            ParcelFileDescriptor.AutoCloseOutputStream(descriptor).use { output ->
+                downloadParallel(url, totalBytes, output.channel, onProgress)
+                output.channel.force(true)
+            }
+        }
+    }
+
+    private suspend fun downloadParallel(
+        url: String,
+        totalBytes: Long,
+        channel: FileChannel,
+        onProgress: (Float?) -> Unit,
+    ) = coroutineScope {
+        val downloadedBytes = AtomicLong(0L)
+        val lastReportedPercent = AtomicInteger(-1)
+        val reportProgress = {
+            val percent = ((downloadedBytes.get() * 100L) / totalBytes).toInt().coerceIn(0, 100)
+            while (true) {
+                val previous = lastReportedPercent.get()
+                if (percent <= previous) break
+                if (lastReportedPercent.compareAndSet(previous, percent)) {
+                    onProgress(percent / 100f)
+                    break
+                }
+            }
+        }
+
+        splitDownloadRanges(totalBytes, PARALLEL_PARTS).map { range ->
+            async(Dispatchers.IO) {
+                val request = Request.Builder()
+                    .url(url)
+                    .header("Range", "bytes=${range.first}-${range.last}")
+                    .build()
+
+                client.newCall(request).execute().use { response ->
+                    if (response.code != 206) {
+                        throw IOException("Server stopped supporting parallel range requests")
+                    }
+                    if (!contentRangeMatches(response.header("Content-Range"), range, totalBytes)) {
+                        throw IOException("Server returned an unexpected download range")
+                    }
+                    val body = response.body
+                    body.byteStream().use { input ->
+                        val expectedBytes = range.last - range.first + 1L
+                        var rangeBytes = 0L
+                        val buffer = ByteArray(BUFFER_SIZE)
+                        while (true) {
+                            coroutineContext.ensureActive()
+                            val count = input.read(buffer)
+                            if (count < 0) break
+                            if (rangeBytes + count > expectedBytes) {
+                                throw IOException("Downloaded range had an unexpected size")
+                            }
+
+                            val bytes = ByteBuffer.wrap(buffer, 0, count)
+                            var writePosition = range.first + rangeBytes
+                            while (bytes.hasRemaining()) {
+                                val written = channel.write(bytes, writePosition)
+                                if (written <= 0) {
+                                    throw IOException("Could not write the downloaded video")
+                                }
+                                writePosition += written
+                            }
+                            rangeBytes += count
+                            downloadedBytes.addAndGet(count.toLong())
+                            reportProgress()
+                        }
+                        if (rangeBytes != expectedBytes) {
+                            throw IOException("Downloaded range had an unexpected size")
+                        }
+                    }
+                }
+            }
+        }.awaitAll()
+    }
+
+    private suspend fun downloadSequentialToMediaStore(
+        context: Context,
+        url: String,
+        probe: ProbeResult,
+        onProgress: (Float?) -> Unit,
+    ) {
+        writePendingVideo(context, probe.fileName, probe.mimeType) { uri ->
+            val output = context.contentResolver.openOutputStream(uri, "w")
+                ?: throw IOException("Could not open the downloaded video")
+            output.buffered().use { destination ->
+                val request = Request.Builder().url(url).build()
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        throw IOException("Server returned HTTP ${response.code}")
+                    }
+                    val totalBytes = response.body.contentLength()
+                        .takeIf { it > 0L }
+                        ?: probe.totalBytes
+                    var downloadedBytes = 0L
+                    var lastReportedPercent = -1
+
+                    response.body.byteStream().use { input ->
+                        val buffer = ByteArray(BUFFER_SIZE)
+                        while (true) {
+                            coroutineContext.ensureActive()
+                            val count = input.read(buffer)
+                            if (count < 0) break
+                            destination.write(buffer, 0, count)
+                            downloadedBytes += count
+                            if (totalBytes != null) {
+                                val percent = ((downloadedBytes * 100L) / totalBytes)
+                                    .toInt()
+                                    .coerceIn(0, 100)
+                                if (percent != lastReportedPercent) {
+                                    lastReportedPercent = percent
+                                    onProgress(percent / 100f)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun writePendingVideo(
+        context: Context,
+        displayName: String,
+        mimeType: String,
+        write: suspend (Uri) -> Unit,
+    ) {
+        val resolver = context.contentResolver
+        val values = ContentValues().apply {
+            put(MediaStore.Video.Media.DISPLAY_NAME, displayName)
+            put(MediaStore.Video.Media.MIME_TYPE, mimeType)
+            put(MediaStore.Video.Media.RELATIVE_PATH, "Movies/Syncplay")
+            put(MediaStore.Video.Media.IS_PENDING, 1)
+        }
+        val uri = resolver.insert(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, values)
+            ?: throw IOException("Could not create the downloaded video")
+
+        try {
+            write(uri)
+
+            values.clear()
+            values.put(MediaStore.Video.Media.IS_PENDING, 0)
+            resolver.update(uri, values, null, null)
+        } catch (error: Throwable) {
+            resolver.delete(uri, null, null)
+            throw error
+        }
+    }
+
+    private fun Response.downloadFileName(url: String): String {
+        val fromDisposition = header("Content-Disposition")
+            ?.let(::parseContentDispositionFileName)
+        val fromUrl = Uri.parse(url).lastPathSegment
+            ?.substringBefore('?')
+            ?.takeIf { it.isNotBlank() }
+        val rawName = fromDisposition ?: fromUrl ?: "syncplay-video-${System.currentTimeMillis()}.mp4"
+        val cleanName = rawName.replace(Regex("""[\\/:*?"<>|]"""), "_").take(180)
+
+        if (cleanName.substringAfterLast('.', "").isNotBlank()) return cleanName
+        val extension = MimeTypeMap.getSingleton()
+            .getExtensionFromMimeType(header("Content-Type")?.substringBefore(';'))
+        return if (extension == null) "$cleanName.mp4" else "$cleanName.$extension"
+    }
+
+    private fun parseContentDispositionFileName(header: String): String? {
+        val encoded = Regex("""filename\*=UTF-8''([^;]+)""", RegexOption.IGNORE_CASE)
+            .find(header)
+            ?.groupValues
+            ?.get(1)
+        if (encoded != null) {
+            return runCatching { URLDecoder.decode(encoded, "UTF-8") }.getOrNull()
+        }
+        return Regex("""filename="?([^";]+)"?""", RegexOption.IGNORE_CASE)
+            .find(header)
+            ?.groupValues
+            ?.get(1)
+    }
+
+    private data class ProbeResult(
+        val totalBytes: Long?,
+        val supportsRanges: Boolean,
+        val fileName: String,
+        val mimeType: String,
+    )
+}

--- a/shared/src/commonMain/composeResources/values-en/strings.xml
+++ b/shared/src/commonMain/composeResources/values-en/strings.xml
@@ -181,6 +181,12 @@
     <string name="room_addmedia_online_details">Load Media from a network URL</string>
     <string name="room_addmedia_online_popup_subtext">Make sure to provide direct links (for example: www.example.com/video.mp4). YouTube and other media streaming services are not supported yet.</string>
     <string name="room_addmedia_online_url">URL address</string>
+    <string name="room_addmedia_online_play_now">Play now</string>
+    <string name="room_addmedia_online_predownload">Pre-download</string>
+    <string name="room_addmedia_online_preparing">Preparing download...</string>
+    <string name="room_addmedia_online_downloading">Downloading %1$d%%</string>
+    <string name="room_addmedia_online_downloaded">Saved %1$s. Select it later from device storage.</string>
+    <string name="room_addmedia_online_download_failed">Download failed: %1$s</string>
     <string name="room_overflow_title">More Options...</string>
     <string name="room_overflow_create_managed_room">Create managed room</string>
     <string name="room_overflow_create_managed_room_tooltip">Create managed room</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -181,6 +181,12 @@
     <string name="room_addmedia_online_details">Load Media from a network URL</string>
     <string name="room_addmedia_online_popup_subtext">Make sure to provide direct links (for example: www.example.com/video.mp4). YouTube and other media streaming services are not supported yet.</string>
     <string name="room_addmedia_online_url">URL address</string>
+    <string name="room_addmedia_online_play_now">Play now</string>
+    <string name="room_addmedia_online_predownload">Pre-download</string>
+    <string name="room_addmedia_online_preparing">Preparing download...</string>
+    <string name="room_addmedia_online_downloading">Downloading %1$d%%</string>
+    <string name="room_addmedia_online_downloaded">Saved %1$s. Select it later from device storage.</string>
+    <string name="room_addmedia_online_download_failed">Download failed: %1$s</string>
     <string name="room_overflow_title">More Options...</string>
     <string name="room_overflow_create_managed_room">Create managed room</string>
     <string name="room_overflow_create_managed_room_tooltip">Create managed room</string>

--- a/shared/src/commonMain/kotlin/app/room/ui/bottombar/RoomMediaAddButton.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/bottombar/RoomMediaAddButton.kt
@@ -18,14 +18,17 @@ import androidx.compose.material.icons.filled.AddLink
 import androidx.compose.material.icons.filled.AddToQueue
 import androidx.compose.material.icons.filled.ContentPaste
 import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -84,8 +87,14 @@ import syncplaymobile.shared.generated.resources.done
 import syncplaymobile.shared.generated.resources.room_addmedia_offline
 import syncplaymobile.shared.generated.resources.room_addmedia_offline_system
 import syncplaymobile.shared.generated.resources.room_addmedia_online
+import syncplaymobile.shared.generated.resources.room_addmedia_online_download_failed
+import syncplaymobile.shared.generated.resources.room_addmedia_online_downloaded
+import syncplaymobile.shared.generated.resources.room_addmedia_online_downloading
 import syncplaymobile.shared.generated.resources.room_addmedia_online_details
+import syncplaymobile.shared.generated.resources.room_addmedia_online_play_now
 import syncplaymobile.shared.generated.resources.room_addmedia_online_popup_subtext
+import syncplaymobile.shared.generated.resources.room_addmedia_online_predownload
+import syncplaymobile.shared.generated.resources.room_addmedia_online_preparing
 import syncplaymobile.shared.generated.resources.room_addmedia_online_url
 import syncplaymobile.shared.generated.resources.room_button_desc_add
 
@@ -289,6 +298,35 @@ fun AddUrlPopup(visibilityState: MutableState<Boolean>) {
         val scope = rememberCoroutineScope()
         val viewmodel = LocalRoomViewmodel.current
         val clipboard = LocalClipboard.current
+        val url = remember { mutableStateOf("") }
+        var downloadInProgress by remember { mutableStateOf(false) }
+        var downloadProgress by remember { mutableStateOf<Float?>(null) }
+        var downloadedFileName by remember { mutableStateOf<String?>(null) }
+        var downloadError by remember { mutableStateOf<String?>(null) }
+        val preDownloader = rememberTvVideoPreDownloader(
+            onProgress = { progress ->
+                downloadInProgress = true
+                downloadProgress = progress
+                downloadedFileName = null
+                downloadError = null
+            },
+            onComplete = { fileName ->
+                downloadInProgress = false
+                downloadProgress = 1f
+                downloadedFileName = fileName
+            },
+            onError = { error ->
+                downloadInProgress = false
+                downloadProgress = null
+                downloadError = error
+            },
+        )
+        val playNow: () -> Unit = {
+            visibilityState.value = false
+            viewmodel.viewModelScope.launch {
+                viewmodel.player.injectVideoURL(url.value.trim())
+            }
+        }
 
         Column(
             modifier = Modifier.fillMaxSize().padding(6.dp),
@@ -318,11 +356,11 @@ fun AddUrlPopup(visibilityState: MutableState<Boolean>) {
             Spacer(Modifier.height(2.dp))
 
             /* The URL input box */
-            val url = remember { mutableStateOf("") }
             TextField(
                 modifier = Modifier.fillMaxWidth(0.9f),
                 shape = RoundedCornerShape(16.dp),
                 singleLine = true,
+                enabled = !downloadInProgress,
                 value = url.value,
                 colors = TextFieldDefaults.colors(
                     focusedContainerColor = Color.DarkGray,
@@ -333,13 +371,16 @@ fun AddUrlPopup(visibilityState: MutableState<Boolean>) {
                     disabledIndicatorColor = Color.Transparent,
                 ),
                 trailingIcon = {
-                    IconButton(onClick = {
-                        scope.launch {
-                            clipboard.getClipEntry()?.getText()?.let { clipboardData ->
-                                url.value = clipboardData
+                    IconButton(
+                        enabled = !downloadInProgress,
+                        onClick = {
+                            scope.launch {
+                                clipboard.getClipEntry()?.getText()?.let { clipboardData ->
+                                    url.value = clipboardData
+                                }
                             }
-                        }
-                    }) {
+                        },
+                    ) {
                         Icon(imageVector = Icons.Filled.ContentPaste, "", tint = MaterialTheme.colorScheme.primary)
                     }
                 },
@@ -359,24 +400,93 @@ fun AddUrlPopup(visibilityState: MutableState<Boolean>) {
                 }
             )
 
-            /* Ok button */
-            Button(
-                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
-                border = BorderStroke(width = 1.dp, color = Color.Black),
-                onClick = {
-                    visibilityState.value = false
+            if (downloadInProgress) {
+                if (downloadProgress == null) {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth(0.65f))
+                    Text(
+                        text = stringResource(Res.string.room_addmedia_online_preparing),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                } else {
+                    LinearProgressIndicator(
+                        progress = { downloadProgress ?: 0f },
+                        modifier = Modifier.fillMaxWidth(0.65f),
+                    )
+                    Text(
+                        text = stringResource(
+                            Res.string.room_addmedia_online_downloading,
+                            ((downloadProgress ?: 0f) * 100f).toInt(),
+                        ),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            } else {
+                downloadedFileName?.let { fileName ->
+                    Text(
+                        text = stringResource(Res.string.room_addmedia_online_downloaded, fileName),
+                        color = MaterialTheme.colorScheme.primary,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+                downloadError?.let { error ->
+                    Text(
+                        text = stringResource(Res.string.room_addmedia_online_download_failed, error),
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
 
-                    if (url.value.trim().isNotBlank()) {
-                        viewmodel.viewModelScope.launch {
-                            viewmodel.player.injectVideoURL(url.value.trim())
+            if (preDownloader == null) {
+                Button(
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+                    border = BorderStroke(width = 1.dp, color = Color.Black),
+                    onClick = {
+                        visibilityState.value = false
+                        if (url.value.trim().isNotBlank()) {
+                            viewmodel.viewModelScope.launch {
+                                viewmodel.player.injectVideoURL(url.value.trim())
+                            }
                         }
+                    },
+                ) {
+                    Icon(imageVector = Icons.Filled.Done, contentDescription = "")
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(Res.string.done), fontSize = 14.sp)
+                }
+            } else {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Button(
+                        enabled = !downloadInProgress && url.value.trim().isNotBlank(),
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+                        border = BorderStroke(width = 1.dp, color = Color.Black),
+                        onClick = playNow,
+                    ) {
+                        Icon(Icons.Filled.PlayArrow, contentDescription = null)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = stringResource(Res.string.room_addmedia_online_play_now),
+                            fontSize = 14.sp,
+                        )
                     }
 
-                },
-            ) {
-                Icon(imageVector = Icons.Filled.Done, "")
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(stringResource(Res.string.done), fontSize = 14.sp)
+                    Button(
+                        enabled = !downloadInProgress && url.value.trim().isNotBlank(),
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary),
+                        border = BorderStroke(width = 1.dp, color = Color.Black),
+                        onClick = { preDownloader(url.value.trim()) },
+                    ) {
+                        Icon(Icons.Filled.Download, contentDescription = null)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = stringResource(Res.string.room_addmedia_online_predownload),
+                            fontSize = 14.sp,
+                        )
+                    }
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/app/room/ui/bottombar/TvVideoPreDownloader.kt
+++ b/shared/src/commonMain/kotlin/app/room/ui/bottombar/TvVideoPreDownloader.kt
@@ -1,0 +1,45 @@
+package app.room.ui.bottombar
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal expect fun rememberTvVideoPreDownloader(
+    onProgress: (Float?) -> Unit,
+    onComplete: (String) -> Unit,
+    onError: (String) -> Unit,
+): ((String) -> Unit)?
+
+internal fun splitDownloadRanges(
+    totalBytes: Long,
+    requestedParts: Int,
+): List<LongRange> {
+    require(totalBytes > 0L)
+    require(requestedParts > 0)
+
+    val partCount = minOf(totalBytes, requestedParts.toLong()).toInt()
+    val baseSize = totalBytes / partCount
+    val remainder = totalBytes % partCount
+    var start = 0L
+
+    return List(partCount) { index ->
+        val size = baseSize + if (index < remainder) 1L else 0L
+        val range = start..(start + size - 1L)
+        start = range.last + 1L
+        range
+    }
+}
+
+internal fun contentRangeMatches(
+    header: String?,
+    expectedRange: LongRange,
+    expectedTotalBytes: Long,
+): Boolean {
+    val match = Regex(
+        pattern = """bytes\s+(\d+)-(\d+)/(\d+)""",
+        option = RegexOption.IGNORE_CASE,
+    ).matchEntire(header?.trim().orEmpty()) ?: return false
+
+    return match.groupValues[1].toLongOrNull() == expectedRange.first &&
+        match.groupValues[2].toLongOrNull() == expectedRange.last &&
+        match.groupValues[3].toLongOrNull() == expectedTotalBytes
+}

--- a/shared/src/commonTest/kotlin/app/room/ui/bottombar/TvVideoPreDownloaderTest.kt
+++ b/shared/src/commonTest/kotlin/app/room/ui/bottombar/TvVideoPreDownloaderTest.kt
@@ -1,0 +1,42 @@
+package app.room.ui.bottombar
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TvVideoPreDownloaderTest {
+
+    @Test
+    fun splitsEveryByteAcrossParallelRanges() {
+        assertEquals(
+            listOf(0L..24L, 25L..49L, 50L..74L, 75L..99L),
+            splitDownloadRanges(totalBytes = 100L, requestedParts = 4),
+        )
+    }
+
+    @Test
+    fun distributesRemainderWithoutGaps() {
+        assertEquals(
+            listOf(0L..2L, 3L..5L, 6L..7L, 8L..9L),
+            splitDownloadRanges(totalBytes = 10L, requestedParts = 4),
+        )
+    }
+
+    @Test
+    fun doesNotCreateEmptyRangesForSmallFiles() {
+        assertEquals(
+            listOf(0L..0L, 1L..1L),
+            splitDownloadRanges(totalBytes = 2L, requestedParts = 4),
+        )
+    }
+
+    @Test
+    fun acceptsOnlyTheRequestedContentRange() {
+        assertTrue(contentRangeMatches("bytes 25-49/100", 25L..49L, 100L))
+        assertTrue(contentRangeMatches("BYTES 25-49/100", 25L..49L, 100L))
+        assertFalse(contentRangeMatches("bytes 0-24/100", 25L..49L, 100L))
+        assertFalse(contentRangeMatches("bytes 25-49/101", 25L..49L, 100L))
+        assertFalse(contentRangeMatches(null, 25L..49L, 100L))
+    }
+}

--- a/shared/src/iosMain/kotlin/app/room/ui/bottombar/TvVideoPreDownloader.ios.kt
+++ b/shared/src/iosMain/kotlin/app/room/ui/bottombar/TvVideoPreDownloader.ios.kt
@@ -1,0 +1,10 @@
+package app.room.ui.bottombar
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun rememberTvVideoPreDownloader(
+    onProgress: (Float?) -> Unit,
+    onComplete: (String) -> Unit,
+    onError: (String) -> Unit,
+): ((String) -> Unit)? = null


### PR DESCRIPTION
## Summary

- Add a TV-only Pre-download action for direct media URLs.
- Download supported files with four concurrent byte ranges directly into one pending MediaStore item.
- Fall back to a sequential request when range downloads are unavailable or return invalid ranges.
- Publish completed files under `Movies/Syncplay` for later playback.

## Behavior

- The network URL dialog shows separate Play now and Pre-download actions when TV pre-download is supported.
- Download progress, completion, and failure are reported in the URL dialog.
- Partial downloads remain pending and are deleted on failure; only complete files become visible in MediaStore.
- Parallel responses are accepted only when each `Content-Range` matches the requested byte interval and total length.
- Non-TV platforms retain the existing Play behavior and do not expose Pre-download.

## Verification

- `./gradlew :shared:testAndroidHostTest :shared:compileAndroidMain`
- `./gradlew :shared:iosSimulatorArm64Test`
- `./gradlew :androidApp:assembleExoOnlyDebug -PexoOnly=true`
- Android TV API 36 emulator: verified the Play now / Pre-download UI.
- Android phone API 36 emulator: verified the original single `Done` action, touch focus and text entry in the URL field, and normal software-keyboard behavior; Play now and Pre-download were absent.
- Ranged-download integration test: a 5 MiB local HTTP file produced one probe plus four `206` range requests, then appeared in MediaStore at 5,242,880 bytes with `is_pending=0`.
- Host tests cover range partitioning, filename sanitization, and `Content-Range` validation.

The in-app local video picker is intentionally excluded and remains in #163. No APKs, recordings, screenshots, or other build artifacts are attached.
